### PR TITLE
Minor Bug Fixes

### DIFF
--- a/Keras Demo - Multiclass.ipynb
+++ b/Keras Demo - Multiclass.ipynb
@@ -136,6 +136,7 @@
     "# convert class vectors to binary class matrices\n",
     "y_train = keras.utils.to_categorical(y_train, num_classes)\n",
     "y_test  = keras.utils.to_categorical(y_test,  num_classes)\n",
+    "y_validation = keras.utils.to_categorical(y_validation, num_classes)\n",
     "\n",
     "print(\"shape of our labels after\" + str(y_train.shape))\n",
     "print(\"the first 3 labels look like:\") \n",
@@ -155,7 +156,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "logistic_reg_model = Sequential()\n",
@@ -172,7 +175,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "logistic_reg_model.compile(loss='categorical_crossentropy', optimizer=SGD(), metrics=['accuracy'])"
@@ -222,7 +227,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "mlp_model = Sequential()\n",
@@ -243,7 +250,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "mlp_model.compile(loss='categorical_crossentropy', optimizer=SGD(), metrics=['accuracy'])"
@@ -289,7 +298,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def depth_accuracy_analysis(x_train, y_train, x_test, y_test, max_layers, layer_size =128, verbose=False):\n",
@@ -325,7 +336,7 @@
     "        mlp_model.compile(loss='categorical_crossentropy', optimizer=SGD(), metrics=['accuracy'])\n",
     "        history = mlp_model.fit(x_train, y_train,\n",
     "                        batch_size=128,\n",
-    "                        epochs=10,\n",
+    "                        epochs=num_epochs,\n",
     "                        verbose=0,\n",
     "                        validation_data=(x_validation, y_validation))\n",
     "        score = mlp_model.evaluate(x_test, y_test, verbose=0)\n",
@@ -342,7 +353,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "max_layers = 30\n",
@@ -358,14 +371,14 @@
    "source": [
     "# Plot Accuracy\n",
     "plt.subplot(1, 2, 1)\n",
-    "plt.plot(range(1, max_layers + 1), map(lambda x: x[1], scores), 'o-')\n",
+    "plt.plot(range(1, max_layers + 1), list(map(lambda x: x[1], scores)), 'o-')\n",
     "plt.title('Behaviour of model accuracy with depth')\n",
     "plt.ylabel('Testing Accuracy')\n",
     "plt.xlabel('Number of layers with {} nodes/layer'.format(layer_size))\n",
     "\n",
     "# Plot Loss\n",
     "plt.subplot(1, 2, 2)\n",
-    "plt.plot(range(1, max_layers + 1), map(lambda x: x[0], scores), 'o-')\n",
+    "plt.plot(range(1, max_layers + 1), list(map(lambda x: x[0], scores)), 'o-')\n",
     "plt.title('Behaviour of model loss with depth')\n",
     "plt.ylabel('Testing loss')\n",
     "plt.xlabel('Number of layers with {} nodes/layer'.format(layer_size))\n",
@@ -430,7 +443,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "cnn_model = Sequential()\n",
@@ -449,7 +464,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "cnn_model.compile(loss='categorical_crossentropy', optimizer=SGD(), metrics=['accuracy'])"
@@ -463,7 +480,7 @@
    "source": [
     "history = cnn_model.fit(x_train, y_train,\n",
     "                    batch_size=128,\n",
-    "                    epochs=10,\n",
+    "                    epochs=num_epochs,\n",
     "                    verbose=1,\n",
     "                    validation_data=(x_validation, y_validation))"
    ]
@@ -495,7 +512,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Best CNN\n",
@@ -517,7 +536,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "best_cnn_model.compile(loss='categorical_crossentropy', optimizer=Adam(), metrics=['accuracy'])"
@@ -531,7 +552,7 @@
    "source": [
     "history = best_cnn_model.fit(x_train, y_train,\n",
     "                             batch_size=128,\n",
-    "                             epochs=10,\n",
+    "                             epochs=num_epochs,\n",
     "                             verbose=1,\n",
     "                             validation_data=(x_validation, y_validation))"
    ]
@@ -602,7 +623,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.5.3"
   }
  },
  "nbformat": 4,

--- a/Keras Demo- Binary.ipynb
+++ b/Keras Demo- Binary.ipynb
@@ -17,7 +17,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import keras\n",
@@ -50,6 +52,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -104,7 +107,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "image = binary_x_train[0]\n",
@@ -141,7 +146,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "binary_model = Sequential()\n",
@@ -173,7 +180,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "binary_model.compile(loss='binary_crossentropy', optimizer=SGD(), metrics=['accuracy'])"
@@ -189,7 +198,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "global_batch_size = 128\n",
@@ -216,7 +227,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "score = binary_model.evaluate(binary_x_test, binary_y_test, verbose=0)\n",
@@ -241,7 +254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.5.3"
   }
  },
  "nbformat": 4,

--- a/Scikit-learn Demo.ipynb
+++ b/Scikit-learn Demo.ipynb
@@ -66,7 +66,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(iris.keys())\n",
@@ -84,7 +86,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(\"Shape of the features:\", iris.data.shape)\n",
@@ -94,7 +98,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# all of the labels\n",
@@ -111,7 +117,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -152,7 +160,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -182,7 +192,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# First, split the data by male/female.\n",
@@ -224,7 +236,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# let's have a look at ages and fares\n",
@@ -247,7 +261,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "#create bins for age and fare\n",
@@ -283,7 +299,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from sklearn.preprocessing import LabelEncoder\n",
@@ -319,7 +337,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from sklearn.model_selection import train_test_split\n",
@@ -358,7 +378,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# to convert all categorical columns to boolean columns\n",
@@ -385,7 +407,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from sklearn import preprocessing\n",
@@ -448,7 +472,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from sklearn.dummy import DummyClassifier\n",
@@ -477,7 +503,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "clf = DummyClassifier('most_frequent')\n",
@@ -501,7 +529,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from sklearn.svm import LinearSVC\n",
@@ -520,7 +550,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -545,7 +577,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -573,7 +607,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from sklearn.model_selection import train_test_split\n",
@@ -623,7 +659,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -681,7 +719,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from sklearn.tree import DecisionTreeClassifier\n",
@@ -717,7 +757,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "clf = DecisionTreeClassifier(criterion='entropy')\n",
@@ -753,7 +795,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "clf = DecisionTreeClassifier(max_depth=2)\n",
@@ -771,7 +815,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# clf.tree_.__getstate__()\n",
@@ -798,7 +844,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from sklearn.ensemble import RandomForestClassifier\n",
@@ -836,7 +884,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from sklearn.linear_model import LogisticRegression\n",
@@ -862,7 +912,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from sklearn.ensemble import AdaBoostClassifier\n",
@@ -888,7 +940,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from sklearn.neighbors import KNeighborsClassifier\n",
@@ -928,7 +982,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "#one-vs-all\n",
@@ -942,7 +998,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "#one-vs-one\n",
@@ -958,7 +1016,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "#multi-class\n",
@@ -972,7 +1032,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "clf = DecisionTreeClassifier(criterion='gini')\n",
@@ -1027,7 +1089,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.5.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- cleared stale outputs
- Fixed a bug in `Keras Demo - Multiclass.ipynb`

Looks like someone forgot to convert validation set lablels

```python
# convert class vectors to binary class matrices
y_train = keras.utils.to_categorical(y_train, num_classes)
y_test  = keras.utils.to_categorical(y_test,  num_classes)
y_validation = keras.utils.to_categorical(y_validation, num_classes)
```

Also, I had some trouble with graphviz on macos. I was able to fix it by `brew install graphviz`.

